### PR TITLE
Hotfix: iOS 10 dependent and crash on nib load

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "DialogContainerController",
-            dependencies: []),
+            dependencies: [],
+            resources: [
+                .process("DialogContainerController.xib"),
+                .process("SimpleDialogViewController.xib")
+            ]),
         .testTarget(
             name: "DialogContainerControllerTests",
             dependencies: ["DialogContainerController"]),

--- a/Package.swift
+++ b/Package.swift
@@ -23,11 +23,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "DialogContainerController",
-            dependencies: [],
-            resources: [
-                .process("DialogContainerController.xib"),
-                .process("SimpleDialogViewController.xib")
-            ]),
+            dependencies: []),
         .testTarget(
             name: "DialogContainerControllerTests",
             dependencies: ["DialogContainerController"]),

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "DialogContainerController",
+    platforms: [
+        .iOS(.v10),
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/DialogContainerController/DialogContainerController.swift
+++ b/Sources/DialogContainerController/DialogContainerController.swift
@@ -47,7 +47,7 @@ public final class DialogContainerController: UIViewController {
         self.contentViewController = contentViewController
         self.presentationSetup = presentationSetup
         
-        super.init(nibName: "DialogContainerController", bundle: nil)
+        super.init(nibName: "DialogContainerController", bundle: Bundle.module)
         
         modalTransitionStyle = presentationSetup.modalTransitionStyle
         modalPresentationStyle = presentationSetup.modalPresentationStyle

--- a/Sources/DialogContainerController/DialogContainerController.swift
+++ b/Sources/DialogContainerController/DialogContainerController.swift
@@ -47,7 +47,7 @@ public final class DialogContainerController: UIViewController {
         self.contentViewController = contentViewController
         self.presentationSetup = presentationSetup
         
-        super.init(nibName: "DialogContainerController", bundle: Bundle(for: DialogContainerController.self))
+        super.init(nibName: "DialogContainerController", bundle: nil)
         
         modalTransitionStyle = presentationSetup.modalTransitionStyle
         modalPresentationStyle = presentationSetup.modalPresentationStyle

--- a/Sources/DialogContainerController/SimpleDialogViewController.swift
+++ b/Sources/DialogContainerController/SimpleDialogViewController.swift
@@ -12,7 +12,7 @@ public final class SimpleDialogViewController: UIViewController {
         self.geometry = geometry
         self.style = style
         self.onAction = onAction
-        super.init(nibName: "SimpleDialogViewController", bundle: nil)
+        super.init(nibName: "SimpleDialogViewController", bundle: Bundle.module)
     }
     
     public required init?(coder aDecoder: NSCoder) {

--- a/Sources/DialogContainerController/SimpleDialogViewController.swift
+++ b/Sources/DialogContainerController/SimpleDialogViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+@available(iOS 10.0, *)
 public final class SimpleDialogViewController: UIViewController {
     
     private let setup: Setup

--- a/Sources/DialogContainerController/SimpleDialogViewController.swift
+++ b/Sources/DialogContainerController/SimpleDialogViewController.swift
@@ -12,7 +12,7 @@ public final class SimpleDialogViewController: UIViewController {
         self.geometry = geometry
         self.style = style
         self.onAction = onAction
-        super.init(nibName: "SimpleDialogViewController", bundle: Bundle(for: SimpleDialogViewController.self))
+        super.init(nibName: "SimpleDialogViewController", bundle: nil)
     }
     
     public required init?(coder aDecoder: NSCoder) {

--- a/Sources/DialogContainerController/Utility.swift
+++ b/Sources/DialogContainerController/Utility.swift
@@ -34,6 +34,7 @@ extension UIColor {
     }
 }
 
+@available(iOS 10.0, *)
 extension UIImage {
     static func solidColor(_ color: UIColor) -> UIImage {
         let size = CGSize(width: 3, height: 3)


### PR DESCRIPTION
We fixed to problems that we encountered the very first version of this library for SPM:
- Compile error: we are using some elements provided by Apple available from iOS 10, so we need to manage this in our package
- Runtime error: it wasn't possible to load the nibs specified by the package because the client app was trying to load them from its bundle, not the one of the package